### PR TITLE
Bind visibility to privacy setting

### DIFF
--- a/data/gschema.xml
+++ b/data/gschema.xml
@@ -6,5 +6,10 @@
 		<summary>Whether indicator is hidden and inactive</summary>
 		<description>Always hide indicator if set to true. While hidden the indicator does not monitor the clipboard.</description>
 	</key>
+	<key name="active" type="b">
+		<default>true</default>
+		<summary>Whether indicator is active</summary>
+		<description>Whether the indicator is monitoring and recording the clipboard contents</description>
+	</key>
 	</schema>
 </schemalist>

--- a/data/gschema.xml
+++ b/data/gschema.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
   <schema path="/io/github/ellie_commons/indicator-clipboard/" id="io.github.ellie_commons.indicator-clipboard">
-	<key name="visible" type="b">
-		<default>true</default>
-		<summary>Whether indicator is visible</summary>
-		<description>Hide indicator if set to false. It is still running, just hidden</description>
+	<key name="always-hide" type="b">
+		<default>false</default>
+		<summary>Whether indicator is hidden and inactive</summary>
+		<description>Always hide indicator if set to true. While hidden the indicator does not monitor the clipboard.</description>
 	</key>
 	</schema>
 </schemalist>

--- a/src/HistoryWidget.vala
+++ b/src/HistoryWidget.vala
@@ -66,6 +66,13 @@ public class Clipboard.HistoryWidget : Gtk.Box {
         }
     }
 
+    public void clear_history () {
+        clipboard_text_set.clear ();
+        clipboard_item_list.@foreach ((child) => {
+            child.destroy ();
+        });
+    }
+
     private class ItemRow : Gtk.ListBoxRow {
         public string text { get; construct; }
         public string prettier_text { get; construct; }

--- a/src/HistoryWidget.vala
+++ b/src/HistoryWidget.vala
@@ -12,6 +12,15 @@ public class Clipboard.HistoryWidget : Gtk.Box {
     public signal void close_request ();
 
     construct {
+        orientation = VERTICAL;
+        spacing = 6;
+
+        var active_switch = new Granite.SwitchModelButton (_("Clipboard Manager")) {
+            description = _("Monitoring the clipboard contents")
+        };
+
+        Clipboard.Indicator.settings.bind ("active", active_switch, "active", DEFAULT);
+
         clipboard_text_set = new Gee.HashSet<string> ();
 
         clipboard_item_list = new Gtk.ListBox () {
@@ -24,6 +33,7 @@ public class Clipboard.HistoryWidget : Gtk.Box {
         scroll_box.hscrollbar_policy = Gtk.PolicyType.NEVER;
         scroll_box.add (clipboard_item_list);
 
+        add (active_switch);
         add (scroll_box);
         show_all ();
 
@@ -105,4 +115,52 @@ public class Clipboard.HistoryWidget : Gtk.Box {
             add (label);
         }
     }
+
+    // Taken from the Code project (https://github.com/elementary/code)
+    private class SettingSwitch : Gtk.Grid {
+        public string label { get; construct; }
+        public string settings_key { get; construct; }
+        public string description { get; construct; }
+
+        public SettingSwitch (string label, string settings_key, string description = "") {
+            Object (
+                description: description,
+                label: label,
+                settings_key: settings_key
+            );
+        }
+
+        construct {
+            var switch_widget = new Gtk.Switch () {
+                valign = CENTER
+            };
+
+            var label_widget = new Gtk.Label (label) {
+                halign = START,
+                hexpand = true,
+                mnemonic_widget = switch_widget
+            };
+
+            column_spacing = 12;
+            attach (label_widget, 0, 0);
+            attach (switch_widget, 1, 0, 1, 2);
+
+            if (description != "") {
+                var description_label = new Gtk.Label (description) {
+                    halign = START,
+                    wrap = true,
+                    xalign = 0
+                };
+                description_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+                description_label.get_style_context ().add_class (Granite.STYLE_CLASS_SMALL_LABEL);
+
+                attach (description_label, 0, 1);
+
+                switch_widget.get_accessible ().accessible_description = description;
+            }
+
+            Clipboard.Indicator.settings.bind (settings_key, switch_widget, "active", DEFAULT);
+        }
+    }
+
 }

--- a/src/HistoryWidget.vala
+++ b/src/HistoryWidget.vala
@@ -4,6 +4,9 @@
  */
 
 public class Clipboard.HistoryWidget : Gtk.Box {
+    private const string ACTIVE_DESCRIPTION = N_("Monitoring the clipboard contents");
+    private const string PRIVACY_DESCRIPTION = N_("Privacy Mode is On");
+
     private Gee.HashSet<string> clipboard_text_set;
     private Gtk.ListBox clipboard_item_list;
     private string last_text = "";
@@ -21,7 +24,7 @@ public class Clipboard.HistoryWidget : Gtk.Box {
         spacing = 6;
 
         active_switch = new Granite.SwitchModelButton (_("Clipboard Manager")) {
-            description = _("Monitoring the clipboard contents")
+            description = _(ACTIVE_DESCRIPTION)
         };
 
         var inactive_header_label = new Granite.HeaderLabel (_("The ClipboardManager is disabled"));
@@ -87,7 +90,6 @@ public class Clipboard.HistoryWidget : Gtk.Box {
                     var new_item = new ItemRow (text);
                     clipboard_item_list.prepend (new_item);
                     clipboard_item_list.select_row (new_item);
-                    clipboard_item_list.show_all ();
                 }
             });
         }
@@ -110,8 +112,10 @@ public class Clipboard.HistoryWidget : Gtk.Box {
         if (privacy_on) {
             stop_waiting_for_text ();
             clear_history ();
+            active_switch.description = _(PRIVACY_DESCRIPTION);
         } else {
             wait_for_text ();
+            active_switch.description = _(ACTIVE_DESCRIPTION);
         }
     }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -5,6 +5,7 @@
 
 public class Clipboard.Indicator : Wingpanel.Indicator {
     private static GLib.Settings settings;
+    private static GLib.Settings gnome_privacy_settings;
     private Gtk.Image panel_icon;
     private HistoryWidget history_widget;
 
@@ -23,7 +24,10 @@ public class Clipboard.Indicator : Wingpanel.Indicator {
 
         settings = new GLib.Settings ("io.github.ellie_commons.indicator-clipboard");
         settings.bind ("visible", this, "visible", GLib.SettingsBindFlags.DEFAULT);
+        gnome_privacy_settings = new Settings ("org.gnome.desktop.privacy");
+        gnome_privacy_settings.bind ("remember-recent-files", this, "visible", GET);
     }
+
 
     public override Gtk.Widget get_display_widget () {
         if (panel_icon == null) {
@@ -32,9 +36,12 @@ public class Clipboard.Indicator : Wingpanel.Indicator {
             if (server_type == Wingpanel.IndicatorManager.ServerType.GREETER) {
                 this.visible = false;
             } else {
-                // var visible_settings = new Settings ("io.elementary.desktop.wingpanel.clipboard");
-                // visible_settings.bind ("show-indicator", this, "visible", SettingsBindFlags.DEFAULT);
-                this.visible = true;
+                this.notify["visible"].connect (() => {
+                    warning ("visible changed to %s", visible.to_string ());
+                    if (!visible) {
+                        ((HistoryWidget) (get_widget ())).clear_history ();
+                    }
+                });
             }
         }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -4,13 +4,13 @@
  */
 
 public class Clipboard.Indicator : Wingpanel.Indicator {
-    private static GLib.Settings settings;
+    public static GLib.Settings settings;
     private static GLib.Settings gnome_privacy_settings;
     private const string NORMAL_ICON_NAME = "edit-copy-symbolic";
     private const string STOPPED_ICON_NAME = "task-past-due-symbolic";
     private Gtk.Image panel_icon;
     private HistoryWidget history_widget;
-    private Gtk.Box inactive_widget;
+    private Gtk.Box privacy_widget;
     public bool always_hide { get; set; }
     public bool privacy_on { get; set; }
 
@@ -37,12 +37,12 @@ public class Clipboard.Indicator : Wingpanel.Indicator {
             label = Granite.TOOLTIP_SECONDARY_TEXT_MARKUP.printf (_("History is off in the Privacy and Security settings")),
             use_markup = true
         };
-        inactive_widget = new Gtk.Box (VERTICAL, 0) {
+        privacy_widget = new Gtk.Box (VERTICAL, 0) {
             margin_start = 6,
             margin_end = 6
         };
-        inactive_widget.add (inactive_header_label);
-        inactive_widget.add (inactive_subheader_label);
+        privacy_widget.add (inactive_header_label);
+        privacy_widget.add (inactive_subheader_label);
         // Ensure correct appearance before showing
         get_display_widget ();
         get_widget ();
@@ -74,13 +74,14 @@ public class Clipboard.Indicator : Wingpanel.Indicator {
             });
 
             this.notify["privacy-on"].connect (update_appearance);
+            // this.notify["privacy-on"].connect (get_widget);
             this.notify["always-hide"].connect (update_appearance);
             update_appearance ();
         }
 
         // There doesn't seem to be a way of stopping Wingpanel showing the (blank) popover in the inactive state
         // So show informative label.
-        return !privacy_on ? history_widget : inactive_widget;
+        return !privacy_on ? history_widget : privacy_widget;
     }
 
     public override void opened () {


### PR DESCRIPTION
Fixes #5 

WITH PRIVACY OFF

<img width="259" height="179" alt="Screenshot from 2025-11-13 17 22 51" src="https://github.com/user-attachments/assets/f1bbfe8e-ae5e-4824-85ae-1de44e49cd63" />

WITH PRIVACY ON

<img width="271" height="137" alt="Screenshot from 2025-11-13 17 19 18" src="https://github.com/user-attachments/assets/4a1ce828-a7e3-4379-8aa2-f0a898351230" />

WITH SWITCH OFF

<img width="265" height="177" alt="Screenshot from 2025-11-13 17 27 33" src="https://github.com/user-attachments/assets/fba9034d-3911-4801-81f8-1747debe85c4" />


Note that with the switch off, the clipboard is no longer monitored but the existing ones remain.  This is so that "favorite" items can be inserted and then not be moved/pushed out by later ones which are not needed.  It is intended that a "Clear" button will be added in a later PR.
