### PR TITLE
Add a tooltip and clear action

### DIFF
--- a/src/HistoryWidget.vala
+++ b/src/HistoryWidget.vala
@@ -105,4 +105,14 @@ public class Clipboard.HistoryWidget : Gtk.Box {
     public uint get_n_items () {
         return clipboard_text_set.size;
     }
+
+
+    public void clear_history () {
+        clipboard_text_set.clear ();
+        clipboard_item_list.@foreach ((child) => {
+            child.destroy ();
+        });
+
+        changed ();
+    }
 }

--- a/src/HistoryWidget.vala
+++ b/src/HistoryWidget.vala
@@ -10,6 +10,7 @@ public class Clipboard.HistoryWidget : Gtk.Box {
     private uint wait_timeout = 0;
 
     public signal void close_request ();
+    public signal void changed ();
 
     construct {
         clipboard_text_set = new Gee.HashSet<string> ();
@@ -52,6 +53,7 @@ public class Clipboard.HistoryWidget : Gtk.Box {
                         clipboard_item_list.prepend (new_item);
                         clipboard_item_list.select_row (new_item);
                         clipboard_item_list.show_all ();
+                        changed ();
                     }
                 });
             }
@@ -97,5 +99,10 @@ public class Clipboard.HistoryWidget : Gtk.Box {
 
             add (label);
         }
+
+    }
+
+    public uint get_n_items () {
+        return clipboard_text_set.size;
     }
 }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -27,10 +27,17 @@ public class Clipboard.Indicator : Wingpanel.Indicator {
 
     public override Gtk.Widget get_display_widget () {
         if (display_widget == null) {
-            display_widget = new Gtk.Image.from_icon_name (
+            var panel_icon = new Gtk.Image.from_icon_name (
                 "edit-copy-symbolic",
                 Gtk.IconSize.SMALL_TOOLBAR
             );
+
+            display_widget = new Gtk.EventBox () {
+                child = panel_icon
+            };
+
+            display_widget.events = BUTTON_PRESS_MASK;
+
 
             if (server_type == Wingpanel.IndicatorManager.ServerType.GREETER) {
                 this.visible = false;
@@ -40,6 +47,18 @@ public class Clipboard.Indicator : Wingpanel.Indicator {
 
             get_widget (); // Initialize history widget
             history_widget.changed.connect (update_tooltip);
+
+            // EventController does not work?
+            display_widget.button_press_event.connect ((event) => {
+                if (event.button == 3) {
+                    history_widget.clear_history ();
+                    return true;
+                }
+
+                return false;
+            });
+
+            display_widget.show_all ();
             update_tooltip ();
         }
 
@@ -70,18 +89,21 @@ public class Clipboard.Indicator : Wingpanel.Indicator {
         string description;
         if (n_items > 0) {
             description = ngettext (
-                _("Clipboard: %u item"),
-                _("Clipboard: %u items"),
+                _("Clipboard Manager: %u item"),
+                _("Clipboard Manager: %u items"),
                 n_items
             ).printf (n_items);
         } else {
-            description = _("Clipboard: Empty");
+            description = _("Clipboard Manager: Empty");
         }
 
-        string accel_label = n_items > 0 ? _("Middle-click to clear") : "";
-        accel_label = Granite.TOOLTIP_SECONDARY_TEXT_MARKUP.printf (accel_label);
-
-        display_widget.tooltip_markup = "%s\n%s".printf (description, accel_label);
+        if (n_items > 0) {
+            string accel_label = n_items > 0 ? _("Middle-click to clear") : "";
+            accel_label = Granite.TOOLTIP_SECONDARY_TEXT_MARKUP.printf (accel_label);
+            display_widget.tooltip_markup = "%s\n%s".printf (description, accel_label);
+        } else {
+            display_widget.tooltip_markup = "%s".printf (description);
+        }
     }
 }
 


### PR DESCRIPTION
Following the pattern of other elementary indicators, a tooltip is added that shows the number of items stored.  The tooltip updates when items are added and removed.

Supplementary label at the moment shows  `middle-click` action